### PR TITLE
Assign output of _direct call to data instead of returning it

### DIFF
--- a/src/itoolkit/transport/direct.py
+++ b/src/itoolkit/transport/direct.py
@@ -77,7 +77,7 @@ class DirectTransport(object):
         if not _available:
             raise RuntimeError("Not supported on this platform")
             
-        return _direct._xmlservice(itool.xml_in(), self.ctl, self.ipc)
+        data = _direct._xmlservice(itool.xml_in(), self.ctl, self.ipc)
         
         if sys.version_info >= (3,0):
             return data.decode('utf-8')


### PR DESCRIPTION
During a refactoring, I accidentally returned the output from
calling the C module instead of assigning it to a variable and
going through the later if check.

Found via flake8 testing by @cclauss. Thanks!

Fixes #24.