### PR TITLE
Allow iPgm.addParm to pass options to iParm

### DIFF
--- a/src/itoolkit/itoolkit.py
+++ b/src/itoolkit/itoolkit.py
@@ -391,6 +391,7 @@ class iPgm (iBase): # noqa N801
 
         Args:
           obj   (obj): iData object or iDs object.
+          iopt (dict): options to pass to iParm constructor
 
         Returns:
           (void)

--- a/src/itoolkit/itoolkit.py
+++ b/src/itoolkit/itoolkit.py
@@ -386,7 +386,7 @@ class iPgm (iBase): # noqa N801
         super(iPgm, self).__init__(iopt, opts)
         self.pcnt = 0
 
-    def addParm(self, obj): # noqa N802
+    def addParm(self, obj, iopt={}): # noqa N802
         """Add a parameter child node.
 
         Args:
@@ -396,7 +396,7 @@ class iPgm (iBase): # noqa N801
           (void)
         """
         self.pcnt += 1
-        p = iParm('p' + str(self.pcnt))
+        p = iParm('p' + str(self.pcnt), iopt)
         p.add(obj)
         self.add(p)
         return self


### PR DESCRIPTION
This change is useful for allowing pass-by-value without having to import `iParm` directly. There may be other uses; whatever you can do with `iParm`, you ought to be able to do on the call to `addParm`.

Example (excerpted) code without this change:
```python
from itoolkit import iToolKit, iSrvPgm, iData
from itoolkit.itoolkit import iParm

s1 = iSrvPgm('srvpgm', PROGRAM, 'ADDDAYS', {'lib': LIBRARY})
p1 = iParm('p1', {'by': 'val'})  # the magic happens here
p1.add(iData('in', '5i0', '-2'))
s1.add(p1)
s1.addRet(iData('out', '10a', ''))
itool.add(s1)
itool.call(trans)
```
To do the same thing with this change:
```python
from itoolkit import iToolKit, iSrvPgm, iData

s1 = iSrvPgm('srvpgm', PROGRAM, 'ADDDAYS', {'lib': LIBRARY})
s1.addParm(iData('in', '5i0', '-2'), {'by': 'val'})
s1.addRet(iData('out', '10a', ''))
itool.add(s1)
itool.call(trans)
```
or:
```python
from itoolkit import iToolKit, iSrvPgm, iData

itool.add(
    iSrvPgm('srvpgm', PROGRAM, 'ADDDAYS', {'lib': LIBRARY})
        .addParm(iData('in', '5i0', '-2'), {'by': 'val'})
        .addRet(iData('out', '10a', '')))
itool.call(trans)
```
