### PR TITLE
Fix database transport error

### DIFF
--- a/src/itoolkit/transport/database.py
+++ b/src/itoolkit/transport/database.py
@@ -61,6 +61,6 @@ class DatabaseTransport(XmlServiceTransport):
 
         # call the procedure using the correct method for this
         # cursor type, which we ascertained in the constructor
-        getattr(cursor, self.func)(cursor, self.query, parms)
+        getattr(cursor, self.func)(self.query, parms)
 
         return "".join(row[0] for row in cursor).rstrip('\0')


### PR DESCRIPTION

Database transport was throwing the following error:
```
getattr(cursor, self.func)(cursor, self.query, parms)
TypeError: callproc() takes at most 3 arguments (4 given)
```
This is because cursor is the implicit "self" reference but also being explicitly passed