### PR TITLE
Fix issues caused by version 1.6

### DIFF
--- a/src/itoolkit/db2/idb2call.py
+++ b/src/itoolkit/db2/idb2call.py
@@ -73,4 +73,4 @@ class iDB2Call(DatabaseTransport): # noqa N801
         Returns:
           The XML returned from XMLSERVICE
         """
-        super(iDB2Call, self).call(itool)
+        return super(iDB2Call, self).call(itool)

--- a/src/itoolkit/lib/ilibcall.py
+++ b/src/itoolkit/lib/ilibcall.py
@@ -40,4 +40,4 @@ class iLibCall(DirectTransport): # noqa N801 gotta live with history
         Returns:
           The XML returned from XMLSERVICE
         """
-        super(iLibCall, self).call(itool)
+        return super(iLibCall, self).call(itool)

--- a/src/itoolkit/rest/irestcall.py
+++ b/src/itoolkit/rest/irestcall.py
@@ -61,4 +61,4 @@ class iRestCall(HttpTransport): # noqa N801
         Returns:
           The XML returned from XMLSERVICE
         """
-        super(iRestCall, self).call(itool)
+        return super(iRestCall, self).call(itool)

--- a/tests/test_unit_idb2call.py
+++ b/tests/test_unit_idb2call.py
@@ -15,7 +15,9 @@ XMLIN = "<?xml version='1.0'?>\n<xmlservice></xmlservice>"
 def test_idb2call_transport_minimal_callproc(database_callproc):
     transport = iDB2Call(database_callproc)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_callproc.cursor()
 
@@ -26,7 +28,9 @@ def test_idb2call_transport_minimal_callproc(database_callproc):
 def test_idb2call_transport_minimal_execute(database_execute):
     transport = iDB2Call(database_execute)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_execute.cursor()
 
@@ -48,7 +52,9 @@ def test_idb2call_with_ibm_db(mocker, database_callproc):
     conn = MockConn()
     transport = iDB2Call(conn)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     Connection.assert_called_once_with(conn)
 
@@ -74,7 +80,9 @@ def test_idb2call_with_uid_pwd(mocker, database_callproc):
 
     transport = iDB2Call(user, password)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     kwargs = dict(database='*LOCAL', user=user, password=password)
     connect.assert_called_once_with(**kwargs)

--- a/tests/test_unit_irestcall.py
+++ b/tests/test_unit_irestcall.py
@@ -22,7 +22,7 @@ XMLIN = "<?xml version='1.0'?>\n<xmlservice></xmlservice>"
 def mock_http_urlopen(mocker):
     mock_urlopen = mocker.patch('itoolkit.transport.http.urlopen')
     mock_response = mocker.Mock()
-    mock_response.read.side_effect = XMLIN.encode('utf-8')
+    mock_response.read.side_effect = (XMLIN.encode('utf-8'),)
     mock_urlopen.return_value = mock_response
 
     return mock_urlopen
@@ -66,9 +66,6 @@ def assert_urlopen_params_correct(mock_urlopen, url, uid, pwd, db2='*LOCAL',
                 'xmlout': int(xmlout)
         }).encode("utf-8"))
 
-    
-
-
 
 def test_irestcall_transport_minimal(mocker):
     mock_urlopen = mock_http_urlopen(mocker)
@@ -79,7 +76,9 @@ def test_irestcall_transport_minimal(mocker):
 
     transport = iRestCall(url, user, password)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -100,7 +99,9 @@ def test_irestcall_transport_without_password(mocker, monkeypatch):
 
     transport = iRestCall(url, user, password)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -120,7 +121,9 @@ def test_irestcall_transport_with_database(mocker):
 
     transport = iRestCall(url, user, password, idb2=database)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -141,7 +144,9 @@ def test_irestcall_transport_with_ipc(mocker):
 
     transport = iRestCall(url, user, password, ipc=ipc)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -162,7 +167,9 @@ def test_irestcall_transport_with_ctl(mocker):
 
     transport = iRestCall(url, user, password, ictl=ctl)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -198,7 +205,9 @@ def test_irestcall_transport_with_size(mocker, recwarn):
     with allow_deprecated():
         transport = iRestCall(url, user, password, isiz=size)
         tk = iToolKit()
-        transport.call(tk)
+        out = transport.call(tk)
+
+        assert isinstance(out, (bytes, str))
         assert len(recwarn) == 2
         assert isinstance(recwarn[0].category, type(DeprecationWarning))
         assert isinstance(recwarn[1].category, type(DeprecationWarning))

--- a/tests/test_unit_transport_database.py
+++ b/tests/test_unit_transport_database.py
@@ -36,7 +36,7 @@ def test_database_transport_execute_schema(database_execute):
     cursor.__iter__.assert_called_once()
 
     assert len(cursor.execute.call_args[0]) > 0
-    assert schema in cursor.execute.call_args[0][1]  # argument 0 is self
+    assert schema in cursor.execute.call_args[0][0]
 
 
 def test_database_transport_callproc_schema(database_execute):
@@ -51,4 +51,4 @@ def test_database_transport_callproc_schema(database_execute):
     cursor.__iter__.assert_called_once()
 
     assert len(cursor.execute.call_args[0]) > 0
-    assert schema in cursor.execute.call_args[0][1]  # argument 0 is self
+    assert schema in cursor.execute.call_args[0][0]

--- a/tests/test_unit_transport_database.py
+++ b/tests/test_unit_transport_database.py
@@ -5,7 +5,9 @@ from itoolkit.transport import DatabaseTransport
 def test_database_transport_callproc(database_callproc):
     transport = DatabaseTransport(database_callproc)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_callproc.cursor()
 
@@ -16,7 +18,9 @@ def test_database_transport_callproc(database_callproc):
 def test_database_transport_execute(database_execute):
     transport = DatabaseTransport(database_execute)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_execute.cursor()
 
@@ -28,7 +32,9 @@ def test_database_transport_execute_schema(database_execute):
     schema = 'MYSCHEMA'
     transport = DatabaseTransport(database_execute, schema=schema)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_execute.cursor()
 
@@ -43,7 +49,9 @@ def test_database_transport_callproc_schema(database_execute):
     schema = 'MYSCHEMA'
     transport = DatabaseTransport(database_execute, schema=schema)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     cursor = database_execute.cursor()
 

--- a/tests/test_unit_transport_http.py
+++ b/tests/test_unit_transport_http.py
@@ -17,7 +17,7 @@ XMLIN = "<?xml version='1.0'?>\n<xmlservice></xmlservice>"
 def mock_http_urlopen(mocker):
     mock_urlopen = mocker.patch('itoolkit.transport.http.urlopen')
     mock_response = mocker.Mock()
-    mock_response.read.side_effect = XMLIN.encode('utf-8')
+    mock_response.read.side_effect = (XMLIN.encode('utf-8'), )
     mock_urlopen.return_value = mock_response
 
     return mock_urlopen
@@ -71,7 +71,9 @@ def test_http_transport_minimal(mocker):
 
     transport = HttpTransport(url, user, password)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,
@@ -91,7 +93,9 @@ def test_http_transport_with_database(mocker):
 
     transport = HttpTransport(url, user, password, database=database)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     assert_urlopen_params_correct(
         mock_urlopen,

--- a/tests/test_unit_transport_ssh.py
+++ b/tests/test_unit_transport_ssh.py
@@ -23,7 +23,9 @@ def test_ssh_transport_minimal(mocker):
 
     transport = SshTransport(ssh_client)
     tk = iToolKit()
-    transport.call(tk)
+    out = transport.call(tk)
+
+    assert isinstance(out, (bytes, str))
 
     command = "/QOpenSys/pkgs/bin/xmlservice-cli"
     ssh_client.exec_command.assert_called_once_with(command)


### PR DESCRIPTION
As a follow-on from #37, fix the deprecated transports not returning any values. Add tests for this case as well as fix tests broken by #37.