### PR TITLE
Compile `direct.c` only on PASE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages, Extension
+from platform import system
 
 
 setup(
@@ -16,7 +17,7 @@ setup(
     ext_modules=[
         Extension('itoolkit/transport/_direct',
                   ['src/itoolkit/transport/direct.c'])
-    ],
+    ] if system() == 'OS400' else [],
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",

--- a/src/itoolkit/transport/direct.py
+++ b/src/itoolkit/transport/direct.py
@@ -3,9 +3,9 @@ import sys
 from .base import XmlServiceTransport
 try:
     from . import _direct
+    # Guard against the dummy version of _direct (for non-PASE builds)
     _available = hasattr(_direct, '_xmlservice')
 except ImportError:
-    # For Sphinx build
     _available = False
 
 __all__ = [


### PR DESCRIPTION
This addresses issue #36. I considered making the proposed change to `direct.py` as well, but decided not to (at least for now) for the following reasons:

1. It's not necessary.
2. I like minimizing diffs.
3. Just in case someone *does* compile `direct.c` on a non-PASE platform, it would be nice not to break because of it.

Signed-off-by: jkyeung <gallium.arsenide@gmail.com>