### PR TITLE
fix: Quote CL cmd in iCmd5250 for shell escaping

### DIFF
--- a/src/itoolkit/itoolkit.py
+++ b/src/itoolkit/itoolkit.py
@@ -119,7 +119,12 @@ except ImportError:
     # python2 has shlex, but not shlex.quote
     # Implement a crude equivalent. We don't care about Python 2 that much
     def quote(s):
-        return '"{}"'.format(s)
+        if ' ' not in s:
+            return s
+
+        # remove first and last space to be less confusing
+        quote_replacement = """ '"'"' """[1:-1]
+        return "'" + s.replace("'", quote_replacement) + "'"
 
 class iBase(object): # noqa N801
     """

--- a/src/itoolkit/itoolkit.py
+++ b/src/itoolkit/itoolkit.py
@@ -113,6 +113,13 @@ import xml.dom.minidom
 import re
 import time
 
+try:
+    from shlex import quote
+except ImportError:
+    # python2 has shlex, but not shlex.quote
+    # Implement a crude equivalent. We don't care about Python 2 that much
+    def quote(s):
+        return '"{}"'.format(s)
 
 class iBase(object): # noqa N801
     """
@@ -329,7 +336,7 @@ class iCmd5250(iSh): # noqa N801
     """
 
     def __init__(self, ikey, icmd, iopt={}):
-        cmd = "/QOpenSys/usr/bin/system " + icmd
+        cmd = "/QOpenSys/usr/bin/system " + quote(icmd)
         super(iCmd5250, self).__init__(ikey, cmd, iopt)
 
 

--- a/tests/test_unit_cmd5250.py
+++ b/tests/test_unit_cmd5250.py
@@ -18,6 +18,7 @@ def test_5250():
 
     assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
 
+
 def test_5250_error_on():
     cmd = 'WRKACTJOB'
     key = 'rtoiu1nqew'
@@ -115,4 +116,3 @@ def test_5250_inner_string():
     assert(element.attrib['var'] == key)
 
     assert(element.text == """/QOpenSys/usr/bin/system 'wrklnk '"'"'/test/file'"'"''""")
-

--- a/tests/test_unit_cmd5250.py
+++ b/tests/test_unit_cmd5250.py
@@ -3,10 +3,6 @@ import xml.etree.ElementTree as ET
 from itoolkit import iCmd5250
 
 
-def to5250(cmd):
-    return "/QOpenSys/usr/bin/system {}".format(cmd)
-
-
 def test_5250():
     cmd = 'WRKACTJOB'
     key = 'lljqezl'
@@ -20,8 +16,7 @@ def test_5250():
     assert('var' in element.attrib)
     assert(element.attrib['var'] == key)
 
-    assert(element.text == to5250(cmd))
-
+    assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
 
 def test_5250_error_on():
     cmd = 'WRKACTJOB'
@@ -37,7 +32,7 @@ def test_5250_error_on():
     assert('var' in element.attrib)
     assert(element.attrib['var'] == key)
 
-    assert(element.text == to5250(cmd))
+    assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
 
 
 def test_5250_error_off():
@@ -54,7 +49,7 @@ def test_5250_error_off():
     assert('var' in element.attrib)
     assert(element.attrib['var'] == key)
 
-    assert(element.text == to5250(cmd))
+    assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
 
 
 def test_5250_row_on():
@@ -71,7 +66,7 @@ def test_5250_row_on():
     assert('var' in element.attrib)
     assert(element.attrib['var'] == key)
 
-    assert(element.text == to5250(cmd))
+    assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
 
 
 def test_5250_row_off():
@@ -88,4 +83,36 @@ def test_5250_row_off():
     assert('var' in element.attrib)
     assert(element.attrib['var'] == key)
 
-    assert(element.text == to5250(cmd))
+    assert(element.text == "/QOpenSys/usr/bin/system WRKACTJOB")
+
+def test_5250_space():
+    cmd = 'WRKACTJOB SBS(*QINTER)'
+    key = 'lknwqekrn'
+
+    element = ET.fromstring(iCmd5250(key, cmd).xml_in())
+    assert(element.tag == 'sh')
+
+    assert('error' in element.attrib)
+    assert(element.attrib['error'] == 'fast')
+
+    assert('var' in element.attrib)
+    assert(element.attrib['var'] == key)
+
+    assert(element.text == "/QOpenSys/usr/bin/system 'WRKACTJOB SBS(*QINTER)'")
+
+
+def test_5250_inner_string():
+    cmd = "wrklnk '/test/file'"
+    key = 'znxvlkja'
+
+    element = ET.fromstring(iCmd5250(key, cmd).xml_in())
+    assert(element.tag == 'sh')
+
+    assert('error' in element.attrib)
+    assert(element.attrib['error'] == 'fast')
+
+    assert('var' in element.attrib)
+    assert(element.attrib['var'] == key)
+
+    assert(element.text == """/QOpenSys/usr/bin/system 'wrklnk '"'"'/test/file'"'"''""")
+


### PR DESCRIPTION
iCmd5250 is just a fancy wrapper around iSh, using the PASE system
command. It did not do any shell escaping/quoting, so it basically only
allowed calling CL commands without parameters or with only positional
parameters because the parentheses would cause the shell to gack.

eg.
iCmd5250('wrkactjob', 'WRKACTJOB SBS(QBATCH)')

basically became

iSh('wrkactjob', '/QOpenSys/usr/bin/system WRKACTJOB SBS(QBATCH)')

When executed, an error would be given from the shell:

sh: syntax error at line 1 : `(' unexpected

The proper fix is to quote the string, but that can be tricky to get
right. Luckily, Python has shlex.quote to do the hard work for us.
https://docs.python.org/3/library/shlex.html#shlex.quote

Fixes #49