### PR TITLE
ci: Add coverage report with Codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,18 @@ matrix:
         - python: pypy3
         - python: nightly
 
-install:
+before_install:
   - pip install --upgrade pip
   - pip install poetry
+  - pip install codecov
+
+install:
   - poetry install --no-root
 
 script:
   - pip install .
   - python -m pytest tests
   - python -m flake8 src
+
+after_success:
+  - python -m codecov

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Python XMLSERVICE Toolkit
 [![Latest version released on PyPi](https://img.shields.io/pypi/v/itoolkit.svg)](https://pypi.python.org/pypi/itoolkit)
 [![](https://img.shields.io/pypi/pyversions/itoolkit.svg)](https://pypi.org/project/itoolkit/)
 [![Documentation Status](https://readthedocs.org/projects/python-itoolkit/badge/?version=latest)](https://python-itoolkit.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/IBM/python-itoolkit/branch/master/graph/badge.svg)](https://codecov.io/gh/IBM/python-itoolkit)
+
 
 itoolkit is a Python interface to the [XMLSERVICE](https://github.com/IBM/xmlservice) toolkit for the [IBM i](https://en.wikipedia.org/wiki/IBM_i) platform.
 
@@ -53,13 +55,13 @@ Tests
 To test the installed itoolkit
 
 ```bash
-python -m pytest tests
+python -m pytest
 ```
 
 To test the local code:
 
 ```bash
-PYTHONPATH=src python -m pytest tests
+PYTHONPATH=src python -m pytest
 ```
 
 Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pytest-mock = ">=1.10.0"
 flake8 = ">=3.6.0"
 mock = "^3.0.5"
 bumpversion = "^0.5.0"
+pytest-cov = "~2.8"
 
 [build-system]
 requires = ["poetry-core>=1.0.0a6"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [flake8]
 max-line-length = 80
+
+[tool:pytest]
+testpaths =
+    tests
+addopts =
+    --cov=itoolkit
+    -r a


### PR DESCRIPTION
Additionally, add pytest configuration to setup.cfg. Note that we can't
add this configuration to pyproject.toml as it's not yet supported. See
https://github.com/pytest-dev/pytest/issues/1556