### PR TITLE
fix: Handle stderr properly in SSH transport

### DIFF
--- a/tests/test_unit_transport_ssh.py
+++ b/tests/test_unit_transport_ssh.py
@@ -30,7 +30,10 @@ def test_ssh_transport_minimal(mocker):
     assert isinstance(out, (bytes, str))
 
     command = "/QOpenSys/pkgs/bin/xmlservice-cli"
-    ssh_client.exec_command.assert_called_once_with(command)
+    ssh_client.exec_command.assert_called_once()
+
+    args = ssh_client.exec_command.call_args
+    assert args[0] == (command,)
 
 
 def test_ssh_transport_raises_when_closed(mocker):


### PR DESCRIPTION
Instead of reading a small amount of data in a blocking way from the
stdout and stderr streams, enable non-blocking I/O and attempt to read
as much data as possible. In addition, make a convenience function to
handle the stream being closed and timeouts so that we don't need to
store a temp variable in the loop. This prevents the situation that lead
to issue #74 where the stderr data is written to the output XML if
stdout is already closed.

Fixes #74