### PR TITLE
fix: Handle Poetry install on Python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
       run: |
-        curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-        | python - -y
+        curl -sSL https://install.python-poetry.org | python - -y --version 1.1.15
     - name: Install dependencies
       run: |
         poetry config virtualenvs.create false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y
-
+          curl -sSL https://install.python-poetry.org | python - -y --version 1.1.15
       - name: Update PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
With Poetry 1.2.0 Python 3.6 is no longer supported. In addition, the
old install-poetry.py mechanism is deprecated and should use
install-python-poetry.org. Switch to using the new installer and use the
(as of now) latest 1.1.x release which still supports Python 3.6.