### PR TITLE
Replace older dbi transport with odbc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ itoolkit is a Python interface to the
 ```python
 from itoolkit import *
 from itoolkit.transport import DatabaseTransport
-import ibm_db_dbi
+import pyodbc
 
-conn = ibm_db_dbi.connect()
+conn = pyodbc.connect("DSN=*LOCAL")
 itransport = DatabaseTransport(conn)
 itool = iToolKit()
 


### PR DESCRIPTION
ODBC is IBM's preferred database connectivity method. The readme example should demonstrate using pyodbc.

Signed-off-by: Alan Seiden <alan@alanseiden.com>